### PR TITLE
Fixes for first day of billing

### DIFF
--- a/providers/azure.py
+++ b/providers/azure.py
@@ -59,7 +59,7 @@ def cost(account_name, password, subscription, client_id, tenant_id) -> "list[Co
         [total := total + i['properties']['paygCostInUSD'] for i in js['value']]
         
         # If we haven't grabbed the billing start and end dates do so now
-        if startDate is None:
+        if startDate is None and js['value']:
             startDate = js['value'][0]['properties']['servicePeriodStartDate']
             endDate = js['value'][0]['properties']['servicePeriodEndDate']
 

--- a/providers/common/softlayer.py
+++ b/providers/common/softlayer.py
@@ -51,8 +51,12 @@ def NextBilling(filter, account_name, api_key) -> CostItem:
     topLevel = json.loads(x.text)
     if not x.ok:
         raise Exception(f'getNextInvoiceTopLevel Failed:\n{json.dumps(topLevel, indent=4)}')
-    startDate = topLevel[0]['cycleStartDate']
-    endDate = topLevel[0]['nextBillDate']
+    
+    startDate = None
+    endDate = None
+    if topLevel:
+        startDate = topLevel[0]['cycleStartDate']
+        endDate = topLevel[0]['nextBillDate']
 
     # Mask for calls to getChildren
     paramsChildren = {


### PR DESCRIPTION
Superfluous exceptions thrown for first day of billing for Softlayer and Azure APIs due to how we're grabbing the billing cycle dates.