### PR TITLE
Missed catching an exception in OVH

### DIFF
--- a/providers/ovhcloud.py
+++ b/providers/ovhcloud.py
@@ -33,7 +33,7 @@ def cost(account_name, endpoint, app_key, app_secret, consumer_key):
     # If its an empty array we've got no expected cost
     try:
         nextBilling = usage[0]['price']['value']
-    except TypeError:
+    except (TypeError, IndexError):
         return [
             CostItem(
                 0,


### PR DESCRIPTION
Missed catching an IndexError exception as OVH CA will return an empty array but US will return an array of length 1 with no price key.